### PR TITLE
fix: 달력 데이터 end_date 수정

### DIFF
--- a/app/services/schedule_service.py
+++ b/app/services/schedule_service.py
@@ -66,7 +66,7 @@ class ScheduleService:
                     break
             # Java CalendarItemDto 생성 규칙에 맞춰 값 세팅
             # startDate: scheduled_time, 없으면 start_time, 없으면 created_at > end_time ? end_time : created_at
-            # endDate: end_time, 없으면 9999-12-31
+            # endDate: scheduled_time, 없으면 end_time, 없으면 9999-12-31
             # startTime: scheduled_time
             # endTime: end_time
             # isScheduled: scheduled_time is not None
@@ -84,7 +84,9 @@ class ScheduleService:
                 task_start_date = None
 
             # endDate 계산
-            if task.end_time:
+            if task.scheduled_time:
+                task_end_date = task.scheduled_time.date()
+            elif task.end_time:
                 task_end_date = task.end_time.date()
             else:
                 task_end_date = date(9999, 12, 31)
@@ -113,18 +115,13 @@ class ScheduleService:
                 if participant.user_id == user.id and participant.category:
                     color = participant.category.color
                     break
-
-            if(task.end_time):
-                task_end_date = task.end_time.date()
-            else:
-                task_end_date = date(9999, 12, 31)
             
             items.append(CalendarItemDto(
                 id=task.id,
                 type=ScheduleType.TASK.value,
                 name=task.name,
                 startDate=task.completed_at,
-                endDate=task_end_date,
+                endDate=task.completed_at,
                 startTime=task.scheduled_time.time() if task.scheduled_time else None,
                 endTime=task.end_time.time() if task.end_time else None,
                 color=color,


### PR DESCRIPTION
# 달력에 스케줄을 표기하는 규칙
1. 일정
시작 날짜 <-> 끝 날짜
2. 완료된 할일
완료된 날짜에만

3. 완료되지 않은 할일 (이게 복잡)
- 시작 : 예정 날짜가 있으면 예정 날짜 -> 없으면 기한 시작 날짜 -> 없으면 생성 날짜
- 끝 : 예정 날짜가 있으면 예정 날짜 -> 없으면 기한 끝 날짜 -> 없으면 무기한 (아주 먼 미래)
즉, 예정 날짜가 있으면 그 날에만 표시되고, 아니면 기한에 표시되는 데, 기한 시작은 없으면 만든 날이 되고, 기한 끝은 없으면 먼 미래가 됨

근데 여기에 살짝 오류가 있어서 수정
