### PR TITLE
feat: add batch schedule update endpoint

### DIFF
--- a/app/services/routine_service.py
+++ b/app/services/routine_service.py
@@ -156,7 +156,7 @@ class RoutineService:
         if not routine.user_id == user.id:
             raise CustomException(status_code=status.HTTP_403_FORBIDDEN, detail="Forbidden: User is not the owner of the routine")
         
-        await routine_crud.delete_by_id(self.db, routine_id)
+        await routine_crud.delete(self.db, routine)
 
     # This method is called from UserService during user creation
     async def create_default_routines_for_user(self, db: AsyncSession, user: user_models.User) -> List[routine_models.Routine]:

--- a/app/services/task_service.py
+++ b/app/services/task_service.py
@@ -85,20 +85,20 @@ class TaskService:
             raise CustomException(status_code=status.HTTP_404_NOT_FOUND, detail="Task not found")
         
         # Update task fields
-        if request.name is not None:
+        if 'name' in request.model_fields_set:
             task.name = request.name
-        if request.location is not None:
+        if 'location' in request.model_fields_set:
             task.location = request.location
-        if request.scheduled_time is not None:
+        if 'scheduled_time' in request.model_fields_set:
             task.scheduled_time = request.scheduled_time
-        if request.start_time is not None:
+        if 'start_time' in request.model_fields_set:
             task.start_time = request.start_time
-        if request.end_time is not None:
+        if 'end_time' in request.model_fields_set:
             task.end_time = request.end_time
-        if request.description is not None:
+        if 'description' in request.model_fields_set:
             task.description = request.description
         # 9/24 추가, 기존 수정에 할일 완료 토글을 합침 (기존의 완료 API는 구버전 앱을 위해 남겨둠)
-        if request.is_completed is not None:
+        if 'is_completed' in request.model_fields_set:
             if request.is_completed:
                 task.is_completed = True
                 # 내가 완료를 누른 날짜에 완료 처리
@@ -117,14 +117,14 @@ class TaskService:
         if not participant:
             raise CustomException(status_code=status.HTTP_404_NOT_FOUND, detail="Participant not found")
 
-        if request.category_id is not None:
+        if 'category_id' in request.model_fields_set:
             category = await category_crud.find_by_id_and_user(self.db, request.category_id, user)
             if not category:
                 raise CustomException(status_code=status.HTTP_404_NOT_FOUND, detail="Category not found")
             participant.category = category
             await participant_crud.save(self.db, participant)
 
-        if request.alert is not None:
+        if 'alert' in request.model_fields_set:
             await alert_crud.delete_by_participant(self.db, participant)
 
             if request.alert and request.alert.task_schedule is not None:

--- a/model/schedule/event/models.py
+++ b/model/schedule/event/models.py
@@ -1,7 +1,6 @@
 from sqlalchemy import Column, BigInteger, String, Date, Time, Enum
 from sqlalchemy.orm import relationship
 
-from ..visibility import Visibility
 from ...base_time_model import BaseTimeModel
 
 class Event(BaseTimeModel):
@@ -17,4 +16,4 @@ class Event(BaseTimeModel):
     end_time = Column(Time, nullable=True)
     source_text = Column(String(500), nullable=True)
     visibility = Column(String(20), nullable=False)
-    participants = relationship("Participant", back_populates="event")
+    participants = relationship("Participant", back_populates="event", cascade="all, delete-orphan")

--- a/model/schedule/participant/models.py
+++ b/model/schedule/participant/models.py
@@ -18,4 +18,4 @@ class Participant(BaseTimeModel):
     event = relationship("Event", back_populates="participants")
     task = relationship("Task", back_populates="participants")
     category = relationship("Category", back_populates="participants")
-    alerts = relationship("Alert", back_populates="participant")
+    alerts = relationship("Alert", back_populates="participant", cascade="all, delete-orphan")

--- a/model/schedule/routine/crud.py
+++ b/model/schedule/routine/crud.py
@@ -40,10 +40,8 @@ class RoutineCRUD:
         await db.refresh(routine)
         return routine
 
-    async def delete_by_id(self, db: AsyncSession, routine_id: int) -> None:
-        await db.execute(
-            delete(models.Routine).where(models.Routine.id == routine_id)
-        )
+    async def delete(self, db: AsyncSession, routine: models.Routine) -> None:
+        await db.delete(routine)
         await db.commit()
 
 routine_crud = RoutineCRUD()

--- a/model/schedule/routine/models.py
+++ b/model/schedule/routine/models.py
@@ -16,4 +16,4 @@ class Routine(BaseTimeModel):
     color = Column(String(10), nullable=False)
 
     user = relationship("User", back_populates="routines")
-    alerts = relationship("Alert", back_populates="routine")
+    alerts = relationship("Alert", back_populates="routine", cascade="all, delete-orphan")

--- a/model/schedule/routine/schemas.py
+++ b/model/schedule/routine/schemas.py
@@ -1,5 +1,5 @@
 from datetime import time
-from typing import Optional, List
+from typing import Optional
 from pydantic import BaseModel, Field
 
 from ..alert.schemas import RoutineAlertResponse

--- a/model/schedule/schemas.py
+++ b/model/schedule/schemas.py
@@ -30,3 +30,21 @@ class CalendarItemDto(BaseModel):
     class Config:
         from_attributes = True
         populate_by_name = True
+
+class OperationLog(BaseModel):
+    table_name: str = Field(..., alias="tableName", description="수정 대상 테이블명: events, tasks, routines 중 하나")
+    row_id: int = Field(..., alias="rowId", description="해당 모델의 ID")
+    operation: str = Field(..., description="create, update, delete 중 하나")
+    payload: Optional[dict] = Field(None, description="수정/생성 요청 바디, 삭제라면 없음")
+    timestamp: int = Field(..., description="오프라인에서 해당 수정이 이루어진 시간 (UNIX timestamp)")
+
+    class Config:
+        from_attributes = True
+        populate_by_name = True
+
+class ScheduleBatchRequest(BaseModel):
+    operations: List[OperationLog]
+
+    class Config:
+        from_attributes = True
+        populate_by_name = True

--- a/model/schedule/task/models.py
+++ b/model/schedule/task/models.py
@@ -1,7 +1,6 @@
 from sqlalchemy import Column, BigInteger, String, Boolean, DateTime, Date, Enum
 from sqlalchemy.orm import relationship
 
-from ..visibility import Visibility
 from ...base_time_model import BaseTimeModel
 
 class Task(BaseTimeModel):
@@ -19,4 +18,4 @@ class Task(BaseTimeModel):
     source_text = Column(String(500), nullable=True)
     visibility = Column(String(20), nullable=False)
 
-    participants = relationship("Participant", back_populates="task")
+    participants = relationship("Participant", back_populates="task", cascade="all, delete-orphan")

--- a/model/schedule/task/schemas.py
+++ b/model/schedule/task/schemas.py
@@ -1,4 +1,4 @@
-from datetime import datetime, date, time
+from datetime import datetime, date
 from typing import Optional
 from pydantic import BaseModel, Field
 


### PR DESCRIPTION
- Introduced a new endpoint for batch processing of schedule operations, allowing updates and deletions for events, tasks, and routines in a single request.
- Updated related schemas to support batch operations.
- Refactored routine deletion logic in RoutineService for consistency.